### PR TITLE
Add RU/EN localization, firmware filtering, chip label mapping, and device docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # ROBONOMICS-ESP Installer
 
-This is a demo installer website for ROBONOMICS ESP32 devices
+This project is the webflasher for devices built by the Robonomics team.
+It provides a browser-based installer for supported ESP firmware builds.
 
-# [webflasher.robonomics.network](https://webflasher.robonomics.network)
+## Production
+
+[webflasher.robonomics.network](https://webflasher.robonomics.network)
+
+## Device Integration Guides
+
+- English guide: [README_ADD_DEVICE.md](./README_ADD_DEVICE.md)
+- Русская инструкция: [README_ADD_DEVICE_RU.md](./README_ADD_DEVICE_RU.md)

--- a/README_ADD_DEVICE.md
+++ b/README_ADD_DEVICE.md
@@ -1,0 +1,135 @@
+# Webflasher: how to add a new device
+
+This guide describes where and how to add a new device/firmware in this project.
+It follows the current project structure with language switching and firmware filtering by language.
+
+## 1) Prepare firmware binaries
+
+Place all required binaries in the `firmware/` directory.
+
+Example:
+- `firmware/MyDevice/bootloader.bin`
+- `firmware/MyDevice/partitions.bin`
+- `firmware/MyDevice/boot_app0.bin`
+- `firmware/MyDevice/mydevice_en.bin`
+- `firmware/MyDevice/mydevice_ru.bin`
+
+If your workflow expects checksum files, add/update corresponding `*.md5` files.
+
+## 2) Create manifest files in `manifest/`
+
+Create one or more files:
+- `manifest/MyDevice_EN.manifest.json`
+- `manifest/MyDevice_RU.manifest.json`
+- optionally `manifest/MyDevice_EN_DEV.manifest.json`, `manifest/MyDevice_RU_DEV.manifest.json`
+
+### Minimal manifest template
+
+```json
+{
+  "name": "mydevice-firmware",
+  "new_install_prompt_erase": true,
+  "new_install_improv_wait_time": 10,
+  "description": "Default description (fallback if translation is not set in js/i18n.js).",
+  "builds": [
+    {
+      "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
+      "improv": false,
+      "parts": [
+        { "path": "../firmware/MyDevice/bootloader.bin?v=R_2026-04.02", "offset": 0 },
+        { "path": "../firmware/MyDevice/partitions.bin?v=R_2026-04.02", "offset": 32768 },
+        { "path": "../firmware/MyDevice/boot_app0.bin?v=R_2026-04.02", "offset": 57344 },
+        { "path": "../firmware/MyDevice/mydevice_en.bin?v=R_2026-04.02", "offset": 65536 }
+      ]
+    }
+  ]
+}
+```
+
+### Important manifest rules
+
+- Keep `chipFamily` as a real chip id (`ESP32-C3`, `ESP32-C6`, `ESP32-S3`, ...).
+- Use `chipLabel` for UI display text.
+  - Example: `chipFamily: "ESP32-C3"` + `chipLabel: "ESP32-C3 (OLD_VERSION_ALTRUIST)"`.
+- If you have multiple chips, add multiple objects in `builds`.
+- `parts[].offset` and file set must match your flashing layout.
+
+## 3) Add new firmware options in `index.html`
+
+File: `index.html`
+
+Inside `<select name="firmware">`, add options with:
+- `value` = manifest base name (without `.manifest.json`)
+- `data-firmware-key` = same key for i18n mapping
+
+Example:
+
+```html
+<option value="MyDevice_EN" data-firmware-key="MyDevice_EN">MyDevice EN</option>
+<option value="MyDevice_EN_DEV" data-firmware-key="MyDevice_EN_DEV">MyDevice EN DEV</option>
+<option value="MyDevice_RU" data-firmware-key="MyDevice_RU">MyDevice RU</option>
+<option value="MyDevice_RU_DEV" data-firmware-key="MyDevice_RU_DEV">MyDevice RU DEV</option>
+```
+
+## 4) Add translations in `js/i18n.js`
+
+File: `js/i18n.js`
+
+For each new `data-firmware-key`, add:
+- label in `firmwareLabels` for `en` and `ru`
+- description in `manifestDescriptions` for `en` and `ru`
+
+Example:
+
+```js
+firmwareLabels: {
+  // ...
+  MyDevice_EN: 'MyDevice EN',
+  MyDevice_EN_DEV: 'MyDevice EN DEV',
+  MyDevice_RU: 'MyDevice RU',
+  MyDevice_RU_DEV: 'MyDevice RU DEV'
+},
+manifestDescriptions: {
+  // ...
+  MyDevice_EN: 'Firmware for MyDevice.',
+  MyDevice_EN_DEV: 'Firmware for MyDevice (dev).',
+  MyDevice_RU: 'Прошивка для MyDevice.',
+  MyDevice_RU_DEV: 'Прошивка для MyDevice (dev).'
+}
+```
+
+## 5) Understand language-based firmware filtering
+
+Current logic in `js/main.js`:
+- EN mode shows only keys containing `_EN` (+ neutral keys without `_EN/_RU`).
+- RU mode shows only keys containing `_RU` (+ neutral keys without `_EN/_RU`).
+
+So naming matters:
+- Use `_EN`/`_RU` in firmware keys if they are language-specific.
+- Do not use `_EN`/`_RU` for language-neutral firmware (example: `em-esp32`, `Hikikomory`).
+
+## 6) Quick checklist before commit
+
+- Manifest file names match option `value` in `index.html`.
+- Every new firmware option has `data-firmware-key`.
+- Every key exists in `js/i18n.js` (`firmwareLabels` + `manifestDescriptions`, both languages).
+- All binary paths in manifest are valid.
+- All `chipFamily` values are valid real chip ids.
+- UI-only chip naming uses `chipLabel`.
+
+## 7) Typical mistakes
+
+- Putting custom text into `chipFamily` instead of `chipLabel`.
+- Adding new option in `index.html` but forgetting i18n entries.
+- Using wrong manifest filename in option `value`.
+- Missing one of EN/RU variants while expecting it in language-specific filtering.
+
+## 8) Minimal end-to-end example
+
+To add `MyDevice` with EN/RU:
+1. Add binaries to `firmware/MyDevice/`.
+2. Add `manifest/MyDevice_EN.manifest.json` and `manifest/MyDevice_RU.manifest.json`.
+3. Add two `<option>` entries in `index.html`.
+4. Add two keys in `firmwareLabels` and `manifestDescriptions` for both `en` and `ru` in `js/i18n.js`.
+5. Open page, switch language, verify the firmware appears only in matching language list and flashes correctly.

--- a/README_ADD_DEVICE_RU.md
+++ b/README_ADD_DEVICE_RU.md
@@ -1,0 +1,137 @@
+# Webflasher: как добавить новое устройство
+
+Этот документ описывает, куда и как вносить изменения, чтобы добавить новое устройство/прошивку в проект.
+Инструкция соответствует текущей структуре проекта с переключением языка и фильтрацией прошивок по языку.
+
+## 1) Подготовьте бинарники прошивки
+
+Разместите все нужные файлы в каталоге `firmware/`.
+
+Пример:
+- `firmware/MyDevice/bootloader.bin`
+- `firmware/MyDevice/partitions.bin`
+- `firmware/MyDevice/boot_app0.bin`
+- `firmware/MyDevice/mydevice_en.bin`
+- `firmware/MyDevice/mydevice_ru.bin`
+
+Если в вашем процессе используются контрольные суммы, добавьте/обновите `*.md5`.
+
+## 2) Создайте manifest-файлы в `manifest/`
+
+Создайте один или несколько файлов:
+- `manifest/MyDevice_EN.manifest.json`
+- `manifest/MyDevice_RU.manifest.json`
+- при необходимости `manifest/MyDevice_EN_DEV.manifest.json`, `manifest/MyDevice_RU_DEV.manifest.json`
+
+### Минимальный шаблон manifest
+
+```json
+{
+  "name": "mydevice-firmware",
+  "new_install_prompt_erase": true,
+  "new_install_improv_wait_time": 10,
+  "description": "Базовое описание (будет fallback, если перевод не задан в js/i18n.js).",
+  "builds": [
+    {
+      "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
+      "improv": false,
+      "parts": [
+        { "path": "../firmware/MyDevice/bootloader.bin?v=R_2026-04.02", "offset": 0 },
+        { "path": "../firmware/MyDevice/partitions.bin?v=R_2026-04.02", "offset": 32768 },
+        { "path": "../firmware/MyDevice/boot_app0.bin?v=R_2026-04.02", "offset": 57344 },
+        { "path": "../firmware/MyDevice/mydevice_en.bin?v=R_2026-04.02", "offset": 65536 }
+      ]
+    }
+  ]
+}
+```
+
+### Важные правила для manifest
+
+- В `chipFamily` указывайте только реальный id чипа (`ESP32-C3`, `ESP32-C6`, `ESP32-S3`, ...).
+- Для отображаемого названия используйте `chipLabel`.
+  - Пример: `chipFamily: "ESP32-C3"` + `chipLabel: "ESP32-C3 (OLD_VERSION_ALTRUIST)"`.
+- Если устройство поддерживает несколько чипов, добавляйте несколько объектов в `builds`.
+- `parts[].offset` и набор файлов должны совпадать с вашей схемой прошивки.
+
+## 3) Добавьте прошивки в `index.html`
+
+Файл: `index.html`
+
+Внутри `<select name="firmware">` добавьте опции:
+- `value` = имя manifest без `.manifest.json`
+- `data-firmware-key` = такой же ключ для i18n
+
+Пример:
+
+```html
+<option value="MyDevice_EN" data-firmware-key="MyDevice_EN">MyDevice EN</option>
+<option value="MyDevice_EN_DEV" data-firmware-key="MyDevice_EN_DEV">MyDevice EN DEV</option>
+<option value="MyDevice_RU" data-firmware-key="MyDevice_RU">MyDevice RU</option>
+<option value="MyDevice_RU_DEV" data-firmware-key="MyDevice_RU_DEV">MyDevice RU DEV</option>
+```
+
+## 4) Добавьте переводы в `js/i18n.js`
+
+Файл: `js/i18n.js`
+
+Для каждого нового `data-firmware-key` добавьте:
+- подпись в `firmwareLabels` для `en` и `ru`
+- описание в `manifestDescriptions` для `en` и `ru`
+
+Пример:
+
+```js
+firmwareLabels: {
+  // ...
+  MyDevice_EN: 'MyDevice EN',
+  MyDevice_EN_DEV: 'MyDevice EN DEV',
+  MyDevice_RU: 'MyDevice RU',
+  MyDevice_RU_DEV: 'MyDevice RU DEV'
+},
+manifestDescriptions: {
+  // ...
+  MyDevice_EN: 'Firmware for MyDevice.',
+  MyDevice_EN_DEV: 'Firmware for MyDevice (dev).',
+  MyDevice_RU: 'Прошивка для MyDevice.',
+  MyDevice_RU_DEV: 'Прошивка для MyDevice (dev).'
+}
+```
+
+## 5) Как работает фильтрация прошивок по языку
+
+Текущая логика в `js/main.js`:
+- в EN-режиме видны только ключи с `_EN` (+ нейтральные ключи без `_EN/_RU`);
+- в RU-режиме видны только ключи с `_RU` (+ нейтральные ключи без `_EN/_RU`).
+
+Отсюда правила именования:
+- используйте `_EN`/`_RU`, если прошивка языко-зависимая;
+- не используйте `_EN`/`_RU` для нейтральных прошивок (например `em-esp32`, `Hikikomory`).
+
+## 6) Быстрый чеклист перед коммитом
+
+- Имя manifest-файла совпадает со `value` в `index.html`.
+- У каждой новой опции есть `data-firmware-key`.
+- Для каждого ключа есть записи в `js/i18n.js` (`firmwareLabels` и `manifestDescriptions`, в обоих языках).
+- Все пути к бинарникам в manifest корректны.
+- Все значения `chipFamily` являются валидными id чипов.
+- Кастомное название чипа задано через `chipLabel`, а не через `chipFamily`.
+
+## 7) Частые ошибки
+
+- Добавили кастомный текст в `chipFamily` вместо `chipLabel`.
+- Добавили опцию в `index.html`, но забыли i18n-ключи.
+- Ошибка в `value` (не совпадает с именем manifest).
+- Ожидается языковая фильтрация, но ключи прошивок не содержат `_EN`/`_RU`.
+
+## 8) Минимальный сценарий добавления (end-to-end)
+
+Чтобы добавить `MyDevice` с EN/RU:
+1. Добавьте бинарники в `firmware/MyDevice/`.
+2. Создайте `manifest/MyDevice_EN.manifest.json` и `manifest/MyDevice_RU.manifest.json`.
+3. Добавьте две опции `<option>` в `index.html`.
+4. Добавьте ключи в `firmwareLabels` и `manifestDescriptions` (для `en` и `ru`) в `js/i18n.js`.
+5. Откройте страницу, переключите язык и проверьте:
+   - в списке отображаются только прошивки соответствующего языка,
+   - прошивка успешно запускается для выбранного устройства.

--- a/index.html
+++ b/index.html
@@ -18,10 +18,20 @@
     <div class="container">
 
       <div class="top-wrapper">
+        <div class="lang-switcher">
+          <label for="lang-select">Language</label>
+          <select id="lang-select" name="language" aria-label="Language switch">
+            <option value="en">EN</option>
+            <option value="ru">RU</option>
+          </select>
+        </div>
 
         <div class="msg invisible" id="customBar" data-simplebar data-simplebar-auto-hide="false" data-simplebar-scrollbar-max-size="70">
           <esp-web-install-button class="invisible">
-            <span slot="unsupported">This browser doesn't support installing things on ESP devices. <span class="bottom-line">Please use Google Chrome or Microsoft Edge desktop version.</span> </span>
+            <span slot="unsupported">
+              <span id="unsupported-main">This browser doesn't support installing things on ESP devices.</span>
+              <span id="unsupported-sub" class="bottom-line">Please use Google Chrome or Microsoft Edge desktop version.</span>
+            </span>
           </esp-web-install-button>
           <p class="description"></p>
         </div>
@@ -29,16 +39,16 @@
         <div class="select-wrapper">
           <select name="firmware" required>
             <option value="" disabled selected>Select Firmware</option>
-            <option value="Altruist_URBAN_EN">Altruist Urban EN</option>
-            <option value="Altruist_URBAN_EN_DEV">Altruist Urban EN DEV</option>
-            <option value="Altruist_URBAN_RU">Altruist Urban RU</option>
-            <option value="Altruist_URBAN_RU_DEV">Altruist Urban RU DEV</option>
-            <option value="Altruist_INSIGHT_EN">Altruist insight EN</option>
-            <option value="Altruist_INSIGHT_EN_DEV">Altruist insight EN DEV</option>
-            <option value="Altruist_INSIGHT_RU">Altruist insight RU</option>
-            <option value="Altruist_INSIGHT_RU_DEV">Altruist insight RU DEV</option>
-            <option value="em-esp32">Energy Monitor</option>
-            <option value="Hikikomory">Hikikomory v1.0</option>
+            <option value="Altruist_URBAN_EN" data-firmware-key="Altruist_URBAN_EN">Altruist Urban EN</option>
+            <option value="Altruist_URBAN_EN_DEV" data-firmware-key="Altruist_URBAN_EN_DEV">Altruist Urban EN DEV</option>
+            <option value="Altruist_URBAN_RU" data-firmware-key="Altruist_URBAN_RU">Altruist Urban RU</option>
+            <option value="Altruist_URBAN_RU_DEV" data-firmware-key="Altruist_URBAN_RU_DEV">Altruist Urban RU DEV</option>
+            <option value="Altruist_INSIGHT_EN" data-firmware-key="Altruist_INSIGHT_EN">Altruist insight EN</option>
+            <option value="Altruist_INSIGHT_EN_DEV" data-firmware-key="Altruist_INSIGHT_EN_DEV">Altruist insight EN DEV</option>
+            <option value="Altruist_INSIGHT_RU" data-firmware-key="Altruist_INSIGHT_RU">Altruist insight RU</option>
+            <option value="Altruist_INSIGHT_RU_DEV" data-firmware-key="Altruist_INSIGHT_RU_DEV">Altruist insight RU DEV</option>
+            <option value="em-esp32" data-firmware-key="em-esp32">Energy Monitor</option>
+            <option value="Hikikomory" data-firmware-key="Hikikomory">Hikikomory v1.0</option>
           </select>
           <select name="chip" required>
             <option class="placeholder" value="" disabled selected>Select chip</option>
@@ -60,7 +70,7 @@
           ESP Installer
         </h1>
 
-        <a target="_blank" href="https://github.com/airalab">Documentation & code</a>
+        <a id="docs-link" target="_blank" href="https://github.com/airalab">Documentation & code</a>
       </div>
   
   
@@ -71,6 +81,7 @@
 
 
   <script src="libs/simplebar.min.js"></script>
+  <script src="js/i18n.js"></script>
   <script src="js/main.js"></script>
   <script type="module" src="https://unpkg.com/esp-web-tools/dist/web/install-button.js?module"></script>
 </body>

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,0 +1,74 @@
+window.WEBFLASHER_I18N = {
+  en: {
+    htmlLang: 'en',
+    languageLabel: 'Language',
+    selectFirmware: 'Select Firmware',
+    selectChip: 'Select chip',
+    connect: 'Connect',
+    docs: 'Documentation & code',
+    unsupportedMain: "This browser doesn't support installing things on ESP devices.",
+    unsupportedSub: "Please use Google Chrome or Microsoft Edge desktop version.",
+    urbanC3Notice: "Important: for correct flashing of ESP32-C3 (OLD_VERSION_ALTRUIST), disconnect the microphone from the noise sensor connector and place a 10 kOhm resistor between 3V3 and SD to apply a pull-up on GPIO8.",
+    readWiki: 'Read article on wiki',
+    manifestDescriptions: {
+      Altruist_URBAN_EN: "This firmware is for the Altruist Air Quality Monitoring Sensor's Urban (Outdoor) Module.",
+      Altruist_URBAN_EN_DEV: "This firmware is for the Altruist Air Quality Monitoring Sensor's Urban (Outdoor) Module.",
+      Altruist_URBAN_RU: 'Build your DIY sensor and become part of the worldwide, open data & civictech network. With Airrohr you can measure air pollution yourself.',
+      Altruist_URBAN_RU_DEV: 'Build your DIY sensor and become part of the worldwide, open data & civictech network. With Airrohr you can measure air pollution yourself.',
+      Altruist_INSIGHT_EN: "Firmware for the Altruist Air Quality Monitoring Sensor's Insight Module.",
+      Altruist_INSIGHT_EN_DEV: "Firmware for the Altruist Air Quality Monitoring Sensor's Insight Module.",
+      Altruist_INSIGHT_RU: "Firmware for the Altruist Air Quality Monitoring Sensor's Insight Module.",
+      Altruist_INSIGHT_RU_DEV: "Firmware for the Altruist Air Quality Monitoring Sensor's Insight Module.",
+      'em-esp32': 'Robonomics Energy Monitoring firmware (fixed Tasmota firmware to work with BL0940 energy meter)',
+      Hikikomory: 'Hikikomory Tamagotchi'
+    },
+    firmwareLabels: {
+      Altruist_URBAN_EN: 'Altruist Urban EN',
+      Altruist_URBAN_EN_DEV: 'Altruist Urban EN DEV',
+      Altruist_URBAN_RU: 'Altruist Urban RU',
+      Altruist_URBAN_RU_DEV: 'Altruist Urban RU DEV',
+      Altruist_INSIGHT_EN: 'Altruist insight EN',
+      Altruist_INSIGHT_EN_DEV: 'Altruist insight EN DEV',
+      Altruist_INSIGHT_RU: 'Altruist insight RU',
+      Altruist_INSIGHT_RU_DEV: 'Altruist insight RU DEV',
+      'em-esp32': 'Energy Monitor',
+      Hikikomory: 'Hikikomory v1.0'
+    }
+  },
+  ru: {
+    htmlLang: 'ru',
+    languageLabel: 'Язык',
+    selectFirmware: 'Выберите прошивку',
+    selectChip: 'Выберите чип',
+    connect: 'Подключить',
+    docs: 'Документация и код',
+    unsupportedMain: 'Этот браузер не поддерживает установку прошивок на ESP-устройства.',
+    unsupportedSub: 'Используйте настольную версию Google Chrome или Microsoft Edge.',
+    urbanC3Notice: 'Важно: для корректной прошивки ESP32-C3 (OLD_VERSION_ALTRUIST) отключите микрофон (датчик шума) от соответствующего разъема и установите резистор 10 кОм между контактами 3V3 и SD, выполнив подтяжку (PULLUP) GPIO8.',
+    readWiki: 'Читать статью в вики',
+    manifestDescriptions: {
+      Altruist_URBAN_EN: 'Это прошивка для городского (уличного) модуля датчика качества воздуха Altruist.',
+      Altruist_URBAN_EN_DEV: 'Это прошивка для городского (уличного) модуля датчика качества воздуха Altruist.',
+      Altruist_URBAN_RU: 'Это прошивка для городского (уличного) модуля датчика качества воздуха Altruist.',
+      Altruist_URBAN_RU_DEV: 'Это прошивка для городского (уличного) модуля датчика качества воздуха Altruist.',
+      Altruist_INSIGHT_EN: 'Прошивка для модуля Insight датчика качества воздуха Altruist.',
+      Altruist_INSIGHT_EN_DEV: 'Прошивка для модуля Insight датчика качества воздуха Altruist.',
+      Altruist_INSIGHT_RU: 'Прошивка для модуля Insight датчика качества воздуха Altruist.',
+      Altruist_INSIGHT_RU_DEV: 'Прошивка для модуля Insight датчика качества воздуха Altruist.',
+      'em-esp32': 'Прошивка Robonomics Energy Monitoring (исправленная прошивка Tasmota для работы с энергоизмерителем BL0940).',
+      Hikikomory: 'Тамагочи Hikikomory'
+    },
+    firmwareLabels: {
+      Altruist_URBAN_EN: 'Altruist Urban EN',
+      Altruist_URBAN_EN_DEV: 'Altruist Urban EN DEV',
+      Altruist_URBAN_RU: 'Альтруист Урбан RU',
+      Altruist_URBAN_RU_DEV: 'Альтруист Урбан RU DEV',
+      Altruist_INSIGHT_EN: 'Altruist insight EN',
+      Altruist_INSIGHT_EN_DEV: 'Altruist insight EN DEV',
+      Altruist_INSIGHT_RU: 'Альтруист Инсайт RU',
+      Altruist_INSIGHT_RU_DEV: 'Альтруист Инсайт RU DEV',
+      'em-esp32': 'Энергомонитор em-esp32c6',
+      Hikikomory: 'Hikikomory v1.0'
+    }
+  }
+};

--- a/js/main.js
+++ b/js/main.js
@@ -4,14 +4,145 @@ document.addEventListener("DOMContentLoaded", () => {
   // description message
   const msgContainer = document.querySelector('.description');
   const msg = document.querySelector('.msg');
+  const langSelect = document.querySelector('#lang-select');
+  const unsupportedMain = document.querySelector('#unsupported-main');
+  const unsupportedSub = document.querySelector('#unsupported-sub');
+  const docsLink = document.querySelector('#docs-link');
+  const unsupportedConnectBtn = document.querySelector('.btn-unsupported');
+  const connectBtn = document.querySelector('.select-wrapper esp-web-install-button .btn');
 
   // select with chips
   const chips = document.querySelector('select[name="chip"]');
 
   // select with firmware 
   const firmware = document.querySelector('select[name="firmware"]');
+  const firmwareOptions = document.querySelectorAll('option[data-firmware-key]');
 
   let unsupported = false;
+  let currentLang = 'en';
+  let activeManifestKey = '';
+  let activeManifestDefaultDescription = '';
+  const i18n = window.WEBFLASHER_I18N || {
+    en: { selectChip: 'Select chip', manifestDescriptions: {}, firmwareLabels: {} }
+  };
+
+  const setChipPlaceholder = () => {
+    chips.innerHTML = `<option class="placeholder" value="" disabled selected>${i18n[currentLang].selectChip}</option>`;
+  };
+
+  const updateChipPlaceholderText = () => {
+    const placeholder = chips.querySelector('option.placeholder');
+    if (placeholder) {
+      placeholder.textContent = i18n[currentLang].selectChip;
+    }
+  };
+
+  const isLocalizedFirmware = (firmwareKey) => firmwareKey.includes('_EN') || firmwareKey.includes('_RU');
+
+  const isFirmwareAllowedForLang = (firmwareKey, lang) => {
+    if (!isLocalizedFirmware(firmwareKey)) {
+      return true;
+    }
+
+    if (lang === 'ru') {
+      return firmwareKey.includes('_RU');
+    }
+
+    return firmwareKey.includes('_EN');
+  };
+
+  const resetFirmwareSelectionUI = () => {
+    firmware.selectedIndex = 0;
+    msgContainer.textContent = '';
+    msg.classList.add('invisible');
+    activeManifestKey = '';
+    activeManifestDefaultDescription = '';
+    setChipPlaceholder();
+    chips.style.display = "block";
+    document.querySelector('.select-wrapper').querySelector('esp-web-install-button').classList.remove('ready');
+  };
+
+  const applyFirmwareVisibilityByLang = (lang) => {
+    let hasSelectedAllowedOption = false;
+    const selectedKey = firmware.value;
+
+    firmwareOptions.forEach((option) => {
+      const key = option.getAttribute('data-firmware-key');
+      const allowed = isFirmwareAllowedForLang(key, lang);
+      option.hidden = !allowed;
+      option.disabled = !allowed;
+
+      if (allowed && key === selectedKey) {
+        hasSelectedAllowedOption = true;
+      }
+    });
+
+    if (selectedKey && !hasSelectedAllowedOption) {
+      resetFirmwareSelectionUI();
+    }
+  };
+
+  const applyLanguage = (lang) => {
+    currentLang = i18n[lang] ? lang : 'en';
+    const t = i18n[currentLang];
+
+    document.documentElement.lang = t.htmlLang;
+    document.querySelector('label[for="lang-select"]').textContent = t.languageLabel;
+    firmware.options[0].textContent = t.selectFirmware;
+    updateChipPlaceholderText();
+    unsupportedMain.textContent = t.unsupportedMain;
+    unsupportedSub.textContent = t.unsupportedSub;
+    unsupportedConnectBtn.textContent = t.connect;
+    connectBtn.textContent = t.connect;
+    docsLink.textContent = t.docs;
+
+    firmwareOptions.forEach((option) => {
+      const key = option.getAttribute('data-firmware-key');
+      option.textContent = t.firmwareLabels[key] || option.textContent;
+    });
+    applyFirmwareVisibilityByLang(currentLang);
+    renderManifestMessage();
+
+    localStorage.setItem('webflasher-lang', currentLang);
+    if (langSelect.value !== currentLang) {
+      langSelect.value = currentLang;
+    }
+  };
+
+  const resolveInitialLang = () => {
+    const urlLang = new URLSearchParams(window.location.search).get('lang');
+    if (urlLang && i18n[urlLang]) {
+      return urlLang;
+    }
+
+    const savedLang = localStorage.getItem('webflasher-lang');
+    if (savedLang && i18n[savedLang]) {
+      return savedLang;
+    }
+
+    const browserLang = (navigator.language || '').toLowerCase();
+    return browserLang.startsWith('ru') ? 'ru' : 'en';
+  };
+
+  const getLocalizedManifestDescription = (manifest, defaultDescription) => {
+    const description = i18n[currentLang].manifestDescriptions[manifest];
+    return description || defaultDescription;
+  };
+
+  const shouldShowUrbanC3Notice = () => {
+    const isUrbanFirmware = activeManifestKey.startsWith('Altruist_URBAN');
+    return isUrbanFirmware && chips.value === 'ESP32-C3';
+  };
+
+  const renderManifestMessage = () => {
+    if (!activeManifestKey || unsupported) {
+      return;
+    }
+
+    const baseDescription = getLocalizedManifestDescription(activeManifestKey, activeManifestDefaultDescription);
+    const notice = shouldShowUrbanC3Notice() ? i18n[currentLang].urbanC3Notice : '';
+    msgContainer.textContent = notice ? `${baseDescription}\n\n${notice}` : baseDescription;
+  };
 
 
 
@@ -24,6 +155,7 @@ document.addEventListener("DOMContentLoaded", () => {
   chips.addEventListener("change", (e) => {
     const button = document.querySelector('.select-wrapper').querySelector('esp-web-install-button');
     button.classList.add('ready');
+    renderManifestMessage();
   });
 
 
@@ -33,7 +165,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const manifestJSON = await fetch(`./manifest/${manifest}.manifest.json`)
     const manifestResult = await manifestJSON.json();
 
-    chips.innerHTML = `<option class="placeholder" value="" disabled selected>Select chip</option>`;
+    setChipPlaceholder();
     chips.style.display="block"
     document.querySelector('.select-wrapper').querySelector('esp-web-install-button').classList.remove('ready')
 
@@ -43,7 +175,7 @@ document.addEventListener("DOMContentLoaded", () => {
       options.forEach(option => {
         const opt = document.createElement('option');
         opt.value = option.chipFamily;
-        opt.innerHTML = option.chipFamily;
+        opt.textContent = option.chipLabel || option.chipFamily;
         chips.appendChild(opt);
       })
     } else {
@@ -52,19 +184,19 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     // display information above selects
-    const descr = manifestResult.description;
+    activeManifestKey = manifest;
+    activeManifestDefaultDescription = manifestResult.description;
 
     msg.classList.remove('invisible');
 
 
     if(!unsupported) {
-
-      msgContainer.innerText = descr;
+      renderManifestMessage();
 
       // if need to add some specific styling or additional tag to specific manifest
       if(manifest === 'airrohr-firmware_en') {
         const a = document.createElement('a');
-        a.innerText = 'Read article on wiki';
+        a.innerText = i18n[currentLang].readWiki;
         a.href = "#"
         msgContainer.append(a)
       }
@@ -99,6 +231,10 @@ document.addEventListener("DOMContentLoaded", () => {
     autoHide: false,
   });
 
+  applyLanguage(resolveInitialLang());
+  langSelect.addEventListener('change', (e) => {
+    applyLanguage(e.target.value);
+  });
   checkSupport();
 
 })

--- a/manifest/Altruist_INSIGHT_EN.manifest.json
+++ b/manifest/Altruist_INSIGHT_EN.manifest.json
@@ -6,6 +6,7 @@
   "builds": [
     {
       "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
       "improv": false,
       "parts": [
         { "path": "../firmware/Altruist/latest32c6ins_boot.bin?v=R_2026-04.02", "offset": 0 },

--- a/manifest/Altruist_INSIGHT_EN_DEV.manifest.json
+++ b/manifest/Altruist_INSIGHT_EN_DEV.manifest.json
@@ -6,6 +6,7 @@
   "builds": [
     {
       "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
       "improv": false,
       "parts": [
         { "path": "../firmware/Altruist/latest32c6ins_boot.bin?v=R_2026-04.02", "offset": 0 },

--- a/manifest/Altruist_INSIGHT_RU.manifest.json
+++ b/manifest/Altruist_INSIGHT_RU.manifest.json
@@ -6,6 +6,7 @@
   "builds": [
     {
       "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
       "improv": false,
       "parts": [
         { "path": "../firmware/Altruist/latest32c6ins_boot.bin?v=R_2026-04.02", "offset": 0 },

--- a/manifest/Altruist_INSIGHT_RU_DEV.manifest.json
+++ b/manifest/Altruist_INSIGHT_RU_DEV.manifest.json
@@ -6,6 +6,7 @@
   "builds": [
     {
       "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
       "improv": false,
       "parts": [
         { "path": "../firmware/Altruist/latest32c6ins_boot.bin?v=R_2026-04.02", "offset": 0 },

--- a/manifest/Altruist_URBAN_EN.manifest.json
+++ b/manifest/Altruist_URBAN_EN.manifest.json
@@ -5,7 +5,8 @@
   "description": "This firmware is for the Altruist Air Quality Monitoring Sensor's Urban (Outdoor) Module.",
   "builds": [
     {
-      "chipFamily": "ESP32-C3 (OLD_VERSION_ALTRUIST)",
+      "chipFamily": "ESP32-C3",
+      "chipLabel": "ESP32-C3 (OLD_VERSION_ALTRUIST)",
       "improv": false,
       "parts": [
         { "path": "../firmware/Altruist/bootloader.bin?v=R_2026-04.02", "offset": 0 },
@@ -16,6 +17,7 @@
     },
     {
       "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
       "improv": false,
       "parts": [
         { "path": "../firmware/Altruist/latest32c6urb_boot.bin?v=R_2026-04.02", "offset": 0 },

--- a/manifest/Altruist_URBAN_EN_DEV.manifest.json
+++ b/manifest/Altruist_URBAN_EN_DEV.manifest.json
@@ -6,6 +6,7 @@
   "builds": [
     {
       "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
       "improv": false,
       "parts": [
         { "path": "../firmware/Altruist/latest32c6urb_boot.bin?v=R_2026-04.02", "offset": 0 },

--- a/manifest/Altruist_URBAN_RU.manifest.json
+++ b/manifest/Altruist_URBAN_RU.manifest.json
@@ -5,7 +5,8 @@
   "description": "Build your DIY sensor and become part of the worldwide, open data & civictech network. With Airrohr you can measure air pollution yourself.",
   "builds": [
     {
-      "chipFamily": "ESP32-C3 (OLD_VERSION_ALTRUIST)",
+      "chipFamily": "ESP32-C3",
+      "chipLabel": "ESP32-C3 (OLD_VERSION_ALTRUIST)",
       "improv": false,
       "parts": [
         { "path": "../firmware/Altruist/bootloader.bin?v=R_2026-04.02", "offset": 0 },
@@ -16,6 +17,7 @@
     },
     {
       "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
       "improv": false,
       "parts": [
         { "path": "../firmware/Altruist/latest32c6urb_boot.bin?v=R_2026-04.02", "offset": 0 },

--- a/manifest/Altruist_URBAN_RU_DEV.manifest.json
+++ b/manifest/Altruist_URBAN_RU_DEV.manifest.json
@@ -6,6 +6,7 @@
   "builds": [
     {
       "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
       "improv": false,
       "parts": [
         { "path": "../firmware/Altruist/latest32c6urb_boot.bin?v=R_2026-04.02", "offset": 0 },

--- a/manifest/Hikikomory.manifest.json
+++ b/manifest/Hikikomory.manifest.json
@@ -6,6 +6,7 @@
   "builds": [
     {
       "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
       "improv": false,
       "parts": [
         { "path": "../firmware/Hikikomory/bootloader.bin", "offset": 0 },

--- a/manifest/em-esp32.manifest.json
+++ b/manifest/em-esp32.manifest.json
@@ -6,6 +6,7 @@
   "builds": [
     {
       "chipFamily": "ESP32-C6",
+      "chipLabel": "ESP32-C6",
       "improv": true,
       "parts": [{ "path": "../firmware/em-esp32/em-esp32c6.factory.bin", "offset": 0 }]
     },

--- a/styles/style.css
+++ b/styles/style.css
@@ -199,6 +199,40 @@ h4 {
   padding-top: calc(100vh / 6);
 }
 
+.lang-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-bottom: var(--gap);
+  color: var(--light-color);
+}
+
+.lang-switcher label {
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+#lang-select {
+  min-width: 88px;
+  width: auto;
+  padding: 8px 28px 8px 10px;
+  margin-right: 0;
+  color: var(--blue-color);
+  border: 2px solid var(--blue-color);
+  font-weight: 500;
+  text-transform: uppercase;
+  background-color: var(--main-color);
+  background-image: url("data:image/svg+xml,%3Csvg width='17' height='15' viewBox='0 0 17 15' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.8096 13.3267C7.59462 14.5682 9.40538 14.5682 10.1904 13.3267L16.5187 3.3189C17.3608 1.98721 16.4039 0.25 14.8283 0.25H2.17168C0.596088 0.25 -0.360794 1.98721 0.481284 3.3189L6.8096 13.3267Z' fill='%2307208F'/%3E%3C/svg%3E%0A");
+  background-repeat: no-repeat;
+  background-position-x: 90%;
+  background-position-y: 50%;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 .msg {
 	height: 100px;
   padding-right:30px;
@@ -285,7 +319,7 @@ h4 {
   z-index: 7;
 }
 
-select {
+.select-wrapper select {
   min-width: 210px;
   width: 100%;
   padding: calc(var(--gap) ) var(--gap);
@@ -305,13 +339,13 @@ select {
   appearance:none;
 }
 
-select:disabled {
+.select-wrapper select:disabled {
   color: var(--grey-color);
   background-image: url("data:image/svg+xml,%3Csvg width='17' height='15' viewBox='0 0 17 15' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.8096 13.3267C7.59462 14.5682 9.40538 14.5682 10.1904 13.3267L16.5187 3.3189C17.3608 1.98721 16.4039 0.25 14.8283 0.25H2.17168C0.596088 0.25 -0.360794 1.98721 0.481284 3.3189L6.8096 13.3267Z' fill='%23B5C0F1'/%3E%3C/svg%3E%0A");
   border-color: var(--light-purple-color);
 }
 
-select:invalid {
+.select-wrapper select:invalid {
   color: var(--grey-color);
 }     
 
@@ -370,7 +404,7 @@ select:invalid {
     margin-bottom: calc(var(--gap) * 6);
   }
 
-  select {
+  .select-wrapper select {
     margin-right: 0;
     margin-bottom: var(--gap);
   }


### PR DESCRIPTION
## Summary

- Add bilingual UI support (EN/RU) with hybrid language resolution:
  - `?lang=...` URL param has highest priority,
  - then saved preference from `localStorage`,
  - then browser language (`navigator.language`).
- Add language-aware firmware list filtering:
  - EN mode shows `_EN*` firmware + language-neutral firmware,
  - RU mode shows `_RU*` firmware + language-neutral firmware.
- Keep flashing compatibility by separating chip display label from chip value:
  - `chipFamily` is used as technical flashing value,
  - `chipLabel` is used for UI display.
- Localize firmware descriptions and add a dedicated Urban C3 flashing notice:
  - for `Altruist_URBAN_*` + `ESP32-C3`, show explicit hardware preparation warning
    (disconnect microphone, add 10 kOhm pull-up between `3V3` and `SD` for GPIO8).
- Add documentation for adding new devices:
  - `README_ADD_DEVICE.md` (EN),
  - `README_ADD_DEVICE_RU.md` (RU),
  - update main `README.md` with project description and guide links.

## Files changed

- `index.html`
- `styles/style.css`
- `js/main.js`
- `js/i18n.js` (new)
- `README.md`
- `README_ADD_DEVICE.md` (new)
- `README_ADD_DEVICE_RU.md` (new)
- manifests updated with `chipLabel` and normalized `chipFamily`:
  - `manifest/Altruist_URBAN_EN.manifest.json`
  - `manifest/Altruist_URBAN_RU.manifest.json`
  - `manifest/Altruist_URBAN_EN_DEV.manifest.json`
  - `manifest/Altruist_URBAN_RU_DEV.manifest.json`
  - `manifest/Altruist_INSIGHT_EN.manifest.json`
  - `manifest/Altruist_INSIGHT_EN_DEV.manifest.json`
  - `manifest/Altruist_INSIGHT_RU.manifest.json`
  - `manifest/Altruist_INSIGHT_RU_DEV.manifest.json`
  - `manifest/Hikikomory.manifest.json`
  - `manifest/em-esp32.manifest.json`

## Why

- Improve UX for Russian-speaking users while keeping EN flow intact.
- Make firmware/chip selection safer and more maintainable.
- Avoid flashing regressions by preserving valid `chipFamily` values.
- Document extension workflow to simplify future onboarding and changes.

## Test plan

- [ ] Open webflasher and verify initial language selection:
  - `?lang=ru` and `?lang=en` override behavior,
  - fallback to saved setting,
  - then browser locale.
- [ ] Switch language via UI and confirm localized labels/buttons/messages.
- [ ] Verify firmware filtering:
  - RU shows only `_RU*` + neutral firmware,
  - EN shows only `_EN*` + neutral firmware.
- [ ] Select `Altruist_URBAN_*` and `ESP32-C3`:
  - confirm Urban ESP32-C3 warning is shown in the current language.
- [ ] Select non-Urban firmware or other chip:
  - confirm warning is not shown.
- [ ] Verify flashing button still receives correct technical chip value (`chipFamily`).
- [ ] Verify chip dropdown displays `chipLabel` when present.